### PR TITLE
fix(ci): make release workflow able to publish + fix Linux deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*"
 
+# tauri-action creates the GitHub Release and uploads assets, which needs write
+# access to repository contents. Without this the build compiles but fails at
+# "create-a-release" with "Resource not accessible by integration".
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build (${{ matrix.os }})
@@ -34,9 +40,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libgtk-3-dev \


### PR DESCRIPTION
The v0.3.0 release run failed on all platforms:
- Windows/macOS compiled fine but failed at create-release with 'Resource not accessible by integration' -> add permissions: contents: write
- Linux apt failed on libappindicator3-dev (gone on ubuntu-24.04) -> drop it, matching ci.yml's working dep list